### PR TITLE
15-bit color conversion changes

### DIFF
--- a/TeheManX_Editor/ColorTools.cs
+++ b/TeheManX_Editor/ColorTools.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace TeheManX_Editor.Forms;
+
+public static class ColorTools
+{
+	// This is mostly the equivalent of:
+	// floor(color * 8) + floor(color / 4)
+	public static byte To24Bit(byte color)
+	{
+		return (byte)((color << 3) | (color >> 2));
+	}
+
+	// Same as above but for int.
+	public static byte To24Bit(int color)
+	{
+		return (byte)((color << 3) | (color >> 2));
+	}
+
+	// Reverse the operation and round the result.
+	public static byte To15Bit(double color)
+	{
+		double offset = Math.Floor(Math.Floor(color / 8.0) / 4.0);
+		return (byte)Math.Round((color - offset) / 8.0);
+	}
+}

--- a/TeheManX_Editor/Forms/ColorDialog.axaml.cs
+++ b/TeheManX_Editor/Forms/ColorDialog.axaml.cs
@@ -25,9 +25,9 @@ public partial class ColorDialog : Window
         InitializeComponent();
         if (!double.IsNaN(pickerLeft))
             Position = new PixelPoint((int)pickerLeft, (int)pickerTop);
-        byte R = (byte)(color % 32 * 8);
-        byte G = (byte)(color / 32 % 32 * 8);
-        byte B = (byte)(color / 1024 % 32 * 8);
+        byte R = ColorTools.To24Bit(color % 32);
+        byte G = ColorTools.To24Bit(color / 32 % 32);
+        byte B = ColorTools.To24Bit(color / 1024 % 32);
         view.Color = Color.FromRgb(R, G, B);
     }
     #endregion Constructors
@@ -40,7 +40,11 @@ public partial class ColorDialog : Window
     }
     private void ColorView_ColorChanged(object? sender, ColorChangedEventArgs e)
     {
-        ushort newC = (ushort)(view.Color.B / 8 * 1024 + view.Color.G / 8 * 32 + view.Color.R / 8);
+        ushort newC = (ushort)(
+			ColorTools.To15Bit(view.Color.B) * 1024 +
+			ColorTools.To15Bit(view.Color.G) * 32 +
+			ColorTools.To15Bit(view.Color.R)
+		);
         Title = $"Set: {row:X}  Color: {col:X}    15BPP RGB #{newC:X4}";
     }
     private void Window_Closing(object? sender, WindowClosingEventArgs e)

--- a/TeheManX_Editor/Forms/ExternalPaletteWindow.axaml.cs
+++ b/TeheManX_Editor/Forms/ExternalPaletteWindow.axaml.cs
@@ -144,9 +144,9 @@ public partial class ExternalPaletteWindow : Window
                         return;
 
                     ushort color = BinaryPrimitives.ReadUInt16LittleEndian(rom.AsSpan(colorOffset + c * 2));
-                    byte R = (byte)(color % 32 * 8);
-                    byte G = (byte)(color / 32 % 32 * 8);
-                    byte B = (byte)(color / 1024 % 32 * 8);
+                    byte R = ColorTools.To24Bit(color % 32);
+                    byte G = ColorTools.To24Bit(color / 32 % 32);
+                    byte B = ColorTools.To24Bit(color / 1024 % 32);
 
                     Rectangle rect = colorGrid.Children[c] as Rectangle;
                     rect.Fill = new SolidColorBrush(Color.FromRgb(R, G, B));
@@ -240,7 +240,11 @@ public partial class ExternalPaletteWindow : Window
         for (int i = 0; i < colors.Count; i++)
         {
             if (i > (colorAmount - 1)) break;
-            ushort newC = (ushort)(colors[i].B / 8 * 1024 + colors[i].G / 8 * 32 + colors[i].R / 8);
+            ushort newC = (ushort)(
+				ColorTools.To15Bit(colors[i].B) * 1024 +
+				ColorTools.To15Bit(colors[i].G) * 32 +
+				ColorTools.To15Bit(colors[i].R) 
+			);
             BinaryPrimitives.WriteUInt16LittleEndian(rom.AsSpan(colorDataOffset + i * 2), newC);
         }
 
@@ -320,9 +324,9 @@ public partial class ExternalPaletteWindow : Window
                         for (int c = 0; c < colorCount; c++)
                         {
                             ushort color = BinaryPrimitives.ReadUInt16LittleEndian(rom.AsSpan(colorOffset + c * 2));
-                            byte R = (byte)(color % 32 * 8);
-                            byte G = (byte)(color / 32 % 32 * 8);
-                            byte B = (byte)(color / 1024 % 32 * 8);
+                            byte R = ColorTools.To24Bit(color % 32);
+                            byte G = ColorTools.To24Bit(color / 32 % 32);
+                            byte B = ColorTools.To24Bit(color / 1024 % 32);
                             bw.Write(R);
                             bw.Write(G);
                             bw.Write(B);
@@ -360,9 +364,9 @@ public partial class ExternalPaletteWindow : Window
                         for (int c = 0; c < colorCount; c++)
                         {
                             ushort color = BinaryPrimitives.ReadUInt16LittleEndian(rom.AsSpan(colorOffset + c * 2));
-                            byte R = (byte)(color % 32 * 8);
-                            byte G = (byte)(color / 32 % 32 * 8);
-                            byte B = (byte)(color / 1024 % 32 * 8);
+                            byte R = ColorTools.To24Bit(color % 32);
+                            byte G = ColorTools.To24Bit(color / 32 % 32);
+                            byte B = ColorTools.To24Bit(color / 1024 % 32);
                             lines.Add($"#{R:X2}{G:X2}{B:X2}");
                         }
                         infoOffset += 4;
@@ -408,13 +412,17 @@ public partial class ExternalPaletteWindow : Window
 
         if (colorDialog.confirm)
         {
-            ushort newC = (ushort)(colorDialog.view.Color.B / 8 * 1024 + colorDialog.view.Color.G / 8 * 32 + colorDialog.view.Color.R / 8);
+            ushort newC = (ushort)(
+				ColorTools.To15Bit(colorDialog.view.Color.B) * 1024 +
+				ColorTools.To15Bit(colorDialog.view.Color.G) * 32 +
+				ColorTools.To15Bit(colorDialog.view.Color.R)
+			);
             BinaryPrimitives.WriteUInt16LittleEndian(rom.AsSpan(offset), newC);
 
             //Convert & Change Clut in GUI
-            byte R = (byte)(newC % 32 * 8);
-            byte G = (byte)(newC / 32 % 32 * 8);
-            byte B = (byte)(newC / 1024 % 32 * 8);
+            byte R = ColorTools.To24Bit(newC % 32);
+            byte G = ColorTools.To24Bit(newC / 32 % 32);
+            byte B = ColorTools.To24Bit(newC / 1024 % 32);
             Color color = Color.FromRgb(R, G, B);
             rect.Fill = new SolidColorBrush(color);
         }

--- a/TeheManX_Editor/Forms/LoadWindow.axaml.cs
+++ b/TeheManX_Editor/Forms/LoadWindow.axaml.cs
@@ -61,9 +61,9 @@ public partial class LoadWindow : Window
                     break;
 
                 ushort color = BinaryPrimitives.ReadUInt16LittleEndian(SNES.rom.AsSpan(colorOffset + c * 2));
-                byte R = (byte)(color % 32 * 8);
-                byte G = (byte)(color / 32 % 32 * 8);
-                byte B = (byte)(color / 1024 % 32 * 8);
+                byte R = ColorTools.To24Bit(color % 32);
+                byte G = ColorTools.To24Bit(color / 32 % 32);
+                byte B = ColorTools.To24Bit(color / 1024 % 32);
 
                 Level.Palette[colorIndex + c] = (uint)(0xFF000000 | (R << 16) | (G << 8) | B);
             }

--- a/TeheManX_Editor/Forms/PaletteEditor.axaml.cs
+++ b/TeheManX_Editor/Forms/PaletteEditor.axaml.cs
@@ -149,9 +149,9 @@ public partial class PaletteEditor : UserControl
         for (int i = 0; i < 16; i++)
         {
             ushort color = BinaryPrimitives.ReadUInt16LittleEndian(SNES.rom.AsSpan(offset + i * 2));
-            byte R = (byte)(color % 32 * 8);
-            byte G = (byte)(color / 32 % 32 * 8);
-            byte B = (byte)(color / 1024 % 32 * 8);
+            byte R = ColorTools.To24Bit(color % 32);
+            byte G = ColorTools.To24Bit(color / 32 % 32);
+            byte B = ColorTools.To24Bit(color / 1024 % 32);
 
             Rectangle rect = paletteGrid2.Children[i] as Rectangle;
 
@@ -485,15 +485,19 @@ public partial class PaletteEditor : UserControl
 
                 if (colorDialog.confirm)
                 {
-                    ushort newC = (ushort)(colorDialog.view.Color.B / 8 * 1024 + colorDialog.view.Color.G / 8 * 32 + colorDialog.view.Color.R / 8);
+                    ushort newC = (ushort)(
+						ColorTools.To15Bit(colorDialog.view.Color.B) * 1024 +
+						ColorTools.To15Bit(colorDialog.view.Color.G) * 32 +
+						ColorTools.To15Bit(colorDialog.view.Color.R)
+					);
                     BinaryPrimitives.WriteUInt16LittleEndian(SNES.rom.AsSpan(colorOffset), newC);
 
                     SNES.edit = true;
 
                     //Convert & Change Clut in GUI
-                    byte R = (byte)(newC % 32 * 8);
-                    byte G = (byte)(newC / 32 % 32 * 8);
-                    byte B = (byte)(newC / 1024 % 32 * 8);
+                    byte R = ColorTools.To24Bit(newC % 32);
+                    byte G = ColorTools.To24Bit(newC / 32 % 32);
+                    byte B = ColorTools.To24Bit(newC / 1024 % 32);
                     Color color = Color.FromRgb(R, G, B);
                     ((Rectangle)sender).Fill = new SolidColorBrush(color);
                     Level.Palette[r * 16 + c] = 0xFF000000 | (uint)((color.R << 16) | (color.G << 8) | color.B);
@@ -609,7 +613,11 @@ public partial class PaletteEditor : UserControl
                 for (int i = 0; i < colors.Count; i++)
                 {
                     if (i > (colorAmount - 1)) break;
-                    ushort newC = (ushort)(colors[i].B / 8 * 1024 + colors[i].G / 8 * 32 + colors[i].R / 8);
+                    ushort newC = (ushort)(
+						ColorTools.To15Bit(colors[i].B) * 1024 +
+						ColorTools.To15Bit(colors[i].G) * 32 +
+						ColorTools.To15Bit(colors[i].R)
+					);
                     BinaryPrimitives.WriteUInt16LittleEndian(SNES.rom.AsSpan(colorDataOffset + i * 2), newC);
                 }
                 SNES.edit = true;
@@ -760,9 +768,9 @@ public partial class PaletteEditor : UserControl
             for (int c = 0; c < 16; c++)
             {
                 ushort color = BinaryPrimitives.ReadUInt16LittleEndian(SNES.rom.AsSpan(colorOffset + c * 2));
-                byte R = (byte)(color % 32 * 8);
-                byte G = (byte)(color / 32 % 32 * 8);
-                byte B = (byte)(color / 1024 % 32 * 8);
+                byte R = ColorTools.To24Bit(color % 32);
+                byte G = ColorTools.To24Bit(color / 32 % 32);
+                byte B = ColorTools.To24Bit(color / 1024 % 32);
 
                 Level.Palette[colorIndex + c] = (uint)(0xFF000000 | (R << 16) | (G << 8) | B);
             }
@@ -911,8 +919,8 @@ public partial class PaletteEditor : UserControl
 
                 /*
                  * Draw 0x200 (512) tiles from VRAM
-                 * Layout: 16 tiles per row × 64 rows
-                 * Each tile is 8×8 pixels
+                 * Layout: 16 tiles per row ï¿½ 64 rows
+                 * Each tile is 8ï¿½8 pixels
                  */
                 for (int ty = 0; ty < 64; ty++)
                 {

--- a/TeheManX_Editor/Forms/TileEditor.axaml.cs
+++ b/TeheManX_Editor/Forms/TileEditor.axaml.cs
@@ -324,9 +324,9 @@ public partial class TileEditor : UserControl
                             return;
 
                         ushort color = BinaryPrimitives.ReadUInt16LittleEndian(SNES.rom.AsSpan(colorOffset + c * 2));
-                        byte R = (byte)(color % 32 * 8);
-                        byte G = (byte)(color / 32 % 32 * 8);
-                        byte B = (byte)(color / 1024 % 32 * 8);
+                        byte R = ColorTools.To24Bit(color % 32);
+                        byte G = ColorTools.To24Bit(color / 32 % 32);
+                        byte B = ColorTools.To24Bit(color / 1024 % 32);
 
                         Palette[((colorIndex + c) >> 4) & 0xF, (colorIndex + c) & 0xF] = Color.FromRgb(R, G, B);
                     }
@@ -884,9 +884,9 @@ public partial class TileEditor : UserControl
                         return;
 
                     ushort color = BinaryPrimitives.ReadUInt16LittleEndian(SNES.rom.AsSpan(colorOffset + c * 2));
-                    byte R = (byte)(color % 32 * 8);
-                    byte G = (byte)(color / 32 % 32 * 8);
-                    byte B = (byte)(color / 1024 % 32 * 8);
+                    byte R = ColorTools.To24Bit(color % 32);
+                    byte G = ColorTools.To24Bit(color / 32 % 32);
+                    byte B = ColorTools.To24Bit(color / 1024 % 32);
 
                     Palette[((colorIndex + c) >> 4) & 0xF, (colorIndex + c) & 0xF] = Color.FromRgb(R, G, B);
                 }

--- a/TeheManX_Editor/Level.cs
+++ b/TeheManX_Editor/Level.cs
@@ -1136,9 +1136,9 @@ namespace TeheManX_Editor
                             return;
 
                         ushort color = BinaryPrimitives.ReadUInt16LittleEndian(SNES.rom.AsSpan(colorOffset + c * 2));
-                        byte R = (byte)(color % 32 * 8);
-                        byte G = (byte)(color / 32 % 32 * 8);
-                        byte B = (byte)(color / 1024 % 32 * 8);
+                        byte R = ColorTools.To24Bit(color % 32);
+                        byte G = ColorTools.To24Bit(color / 32 % 32);
+                        byte B = ColorTools.To24Bit(color / 1024 % 32);
 
                         Palette[colorIndex + c] = (uint)(0xFF000000 | (R << 16) | (G << 8) | B);
                     }
@@ -1215,9 +1215,9 @@ namespace TeheManX_Editor
                                 return;
 
                             ushort color = BinaryPrimitives.ReadUInt16LittleEndian(SNES.rom.AsSpan(colorOffset + c * 2));
-                            byte R = (byte)(color % 32 * 8);
-                            byte G = (byte)(color / 32 % 32 * 8);
-                            byte B = (byte)(color / 1024 % 32 * 8);
+                            byte R = ColorTools.To24Bit(color % 32);
+                            byte G = ColorTools.To24Bit(color / 32 % 32);
+                            byte B = ColorTools.To24Bit(color / 1024 % 32);
 
                             Palette[colorIndex + c] = (uint)(0xFF000000 | (R << 16) | (G << 8) | B);
                         }
@@ -1586,9 +1586,9 @@ namespace TeheManX_Editor
                             break;
 
                         ushort color = BinaryPrimitives.ReadUInt16LittleEndian(SNES.rom.AsSpan(colorOffset + c * 2));
-                        byte R = (byte)(color % 32 * 8);
-                        byte G = (byte)(color / 32 % 32 * 8);
-                        byte B = (byte)(color / 1024 % 32 * 8);
+                        byte R = ColorTools.To24Bit(color % 32);
+                        byte G = ColorTools.To24Bit(color / 32 % 32);
+                        byte B = ColorTools.To24Bit(color / 1024 % 32);
 
                         palette[c + colorIndex - 0x80] = (uint)(0xFF000000 | (R << 16) | (G << 8) | B);
                     }


### PR DESCRIPTION
So. I noticed the way the editor renders colours is just multiply stuff `* 8`
This make pure white `31` be a converted to grey-ish color in the screen.

GDI/DirectX/OpenGL, others API, amost every TV, and most emulators use `(color << 3) | (color >> 2)` to convert it.
This is know as the Bit-Replication color conversion as is the standard almost everywhere.

So, I replaced all instances I could find with that conversion, both forwards and backwards.
To match what one would see in a real SNES and emulators.
(Hopefully did not miss anything)